### PR TITLE
Add pkgdown footer components

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -18,6 +18,9 @@ footer:
   structure:
     left: [developed_by, built_with, legal]
     right: [blank]
+  components:
+    legal: "<br>Copyright &copy; 2023 Merck & Co., Inc., Rahway, NJ, USA and its affiliates. All rights reserved."
+    blank: "<span></span>"
 
 articles:
 - title: Get started


### PR DESCRIPTION
This PR adds the pkgdown footer components to `_pkgdown.yml` so the copyright text can render properly.