### PR TITLE
Fix pkgdown TOC squeezed to bottom issue in vignettes with wide elements

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -5,6 +5,7 @@ url: https://merck.github.io/forestly/
 template:
   bootstrap: 5
   bslib:
+    preset: "bootstrap"
     primary: "#00857c"
     navbar-light-brand-color: "#fff"
     navbar-light-brand-hover-color: "#fff"

--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -27,3 +27,17 @@ footer {
 .sidebar {
     float: right;
 }
+
+/* hotfix for toc squeezed to bottom issue in vignettes with wide elements */
+@media (min-width: 1200px) {
+    .container {
+        width: 1320px !important;
+    }
+}
+
+@media (min-width: 576px) {
+    #toc {
+        position: relative;
+        top: 0;
+    }
+}

--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -1,5 +1,6 @@
 /* navbar background */
-.bg-light, .navbar-light {
+.bg-light,
+.navbar-light {
     background-color: #00857c !important;
 }
 
@@ -22,7 +23,7 @@ footer {
     padding-top: 1rem;
     padding-bottom: 1rem;
 }
-.sidebar{
-  float:right;
-}
 
+.sidebar {
+    float: right;
+}


### PR DESCRIPTION
This PR:

- Sets `preset` to `"bootstrap"` in `_pkgdown.yml` explicitly, to avoid the theming changes due to bslib 0.6.0 (released 2023-11-21) changing the default of preset to `"shiny"`.
- Fixes the "TOC being squeezed to bottom" issue in vignettes with wide elements.
  This includes setting a wider container width for a min-width 1200px container rule (coming from somewhere) and make the TOC stay at the top instead of being sticky.