### PR TITLE
Remove `library()` calls from tests

### DIFF
--- a/tests/testthat/test-ae_forestly.R
+++ b/tests/testthat/test-ae_forestly.R
@@ -1,6 +1,3 @@
-library(metalite)
-library(metalite.ae)
-
 tmp <- metalite.ae::meta_ae_example() |>
   prepare_ae_forestly(
     population = "apat",

--- a/tests/testthat/test-format_ae_forestly.R
+++ b/tests/testthat/test-format_ae_forestly.R
@@ -1,6 +1,3 @@
-library(metalite)
-library(metalite.ae)
-
 out <- metalite.ae::meta_ae_example() |>
   prepare_ae_forestly(
     population = "apat",

--- a/tests/testthat/test-independent-testing-meta_forestly.R
+++ b/tests/testthat/test-independent-testing-meta_forestly.R
@@ -1,6 +1,3 @@
-library(metalite)
-library(metalite.ae)
-
 # Create input object
 adsl <- r2rtf::r2rtf_adsl |> dplyr::mutate(TRTA = TRT01A)
 adae <- r2rtf::r2rtf_adae

--- a/tests/testthat/test-prepare_ae_forestly.R
+++ b/tests/testthat/test-prepare_ae_forestly.R
@@ -1,6 +1,3 @@
-library(metalite)
-library(metalite.ae)
-
 # meta <-
 #   adsl <- r2rtf::r2rtf_adsl
 #   adsl$TRTA <- adsl$TRT01A


### PR DESCRIPTION
Similar to https://github.com/Merck/metalite/pull/161, this PR removes `library()` calls from tests and qualifies the namespaces explicitly.