### PR TITLE
Make tests self-contained

### DIFF
--- a/tests/testthat/helper-ae_forestly.R
+++ b/tests/testthat/helper-ae_forestly.R
@@ -1,0 +1,11 @@
+# Helper functions used by test-ae_forestly.R
+
+test_ae_forestly <- function() {
+  metalite.ae::meta_ae_example() |>
+    prepare_ae_forestly(
+      population = "apat",
+      observation = "wk12",
+      parameter = "any;rel;ser"
+    ) |>
+    format_ae_forestly(display = c("n", "prop", "fig_prop"))
+}

--- a/tests/testthat/helper-format_ae_forestly.R
+++ b/tests/testthat/helper-format_ae_forestly.R
@@ -1,0 +1,10 @@
+# Helper functions used by test-format_ae_forestly.R
+
+test_format_ae_forestly <- function() {
+  prepare_ae_forestly(
+    metalite.ae::meta_ae_example(),
+    population = "apat",
+    observation = "wk12",
+    parameter = "any;rel;ser"
+  )
+}

--- a/tests/testthat/helper-meta_forestly.R
+++ b/tests/testthat/helper-meta_forestly.R
@@ -1,0 +1,28 @@
+# Helper functions used by test-independent-testing-meta_forestly.R
+
+test_meta_forestly_1 <- function() {
+  adsl <- r2rtf::r2rtf_adsl |> dplyr::mutate(TRTA = TRT01A)
+  adae <- r2rtf::r2rtf_adae
+
+  meta_forestly(
+    adsl,
+    adae,
+    population_term = "apat",
+    observation_term = "wk12",
+    parameter_term = "any;rel;ser"
+  )
+}
+
+test_meta_forestly_2 <- function() {
+  adsl <- r2rtf::r2rtf_adsl |> dplyr::mutate(TRTA = TRT01A)
+  adae <- r2rtf::r2rtf_adae
+
+  meta_forestly(
+    adsl, adae,
+    population_term = "trt",
+    population_subset = TRTFL == "Y",
+    observation_term = "trtem",
+    observation_subset = TRTEMFL == "Y" & TRTFL == "Y",
+    parameter_term = "any;g35"
+  )
+}

--- a/tests/testthat/test-ae_forestly.R
+++ b/tests/testthat/test-ae_forestly.R
@@ -1,26 +1,19 @@
-tmp <- metalite.ae::meta_ae_example() |>
-  prepare_ae_forestly(
-    population = "apat",
-    observation = "wk12",
-    parameter = "any;rel;ser"
-  )
-
-outdata <- tmp |> format_ae_forestly(display = c("n", "prop", "fig_prop"))
-
 test_that("ae_forestly(): default setting can be executed without error", {
+  outdata <- test_ae_forestly()
   html <- outdata |> ae_forestly()
   html <- html[[length(html)]]
 
-  testthat::expect_equal(html$name, "div")
-  testthat::expect_equal(html$attribs$class, "container-fluid crosstalk-bscols")
-  testthat::expect_true(grepl("width:1400px", html$children[[1]], fixed = TRUE))
-  testthat::expect_true(grepl("Incidence (%) in One or More Treatment Groups", html$children[[1]], fixed = TRUE))
+  expect_equal(html$name, "div")
+  expect_equal(html$attribs$class, "container-fluid crosstalk-bscols")
+  expect_true(grepl("width:1400px", html$children[[1]], fixed = TRUE))
+  expect_true(grepl("Incidence (%) in One or More Treatment Groups", html$children[[1]], fixed = TRUE))
 })
 
 test_that("ae_forestly(): test filter and width option", {
+  outdata <- test_ae_forestly()
   html <- outdata |> ae_forestly(filter = c("n"), width = 1500)
   html <- html[[length(html)]]
 
-  testthat::expect_true(grepl("width:1500px", html$children[[1]], fixed = TRUE))
-  testthat::expect_true(grepl("Number of AE in One or More Treatment Groups", html$children[[1]], fixed = TRUE))
+  expect_true(grepl("width:1500px", html$children[[1]], fixed = TRUE))
+  expect_true(grepl("Number of AE in One or More Treatment Groups", html$children[[1]], fixed = TRUE))
 })

--- a/tests/testthat/test-format_ae_forestly.R
+++ b/tests/testthat/test-format_ae_forestly.R
@@ -1,11 +1,5 @@
-out <- metalite.ae::meta_ae_example() |>
-  prepare_ae_forestly(
-    population = "apat",
-    observation = "wk12",
-    parameter = "any;rel;ser"
-  )
-
 test_that("Set `display` to ('n', 'prop', 'diff') then one has an additional risk difference column", {
+  out <- test_format_ae_forestly()
   ae_frm <- format_ae_forestly(
     out,
     display = c("n", "prop", "diff"),
@@ -29,6 +23,7 @@ test_that("Set `display` to ('n', 'prop', 'diff') then one has an additional ris
 })
 
 test_that("Set `display` to ('n', 'prop', 'total') then one has total column", {
+  out <- test_format_ae_forestly()
   ae_frm <- format_ae_forestly(
     out,
     display = c("n", "prop", "total"),
@@ -53,6 +48,7 @@ test_that("Set `display` to ('n', 'prop', 'total') then one has total column", {
 
 test_that("1. Set `display` to ('n', 'prop', 'total', 'diff') and change column width using argument
            2. Change `diff_label` to 'MK-xxxx <- Favor -> Placebo' and 'footer_space' to change location of footer", {
+  out <- test_format_ae_forestly()
   ae_frm <- format_ae_forestly(
     out,
     display = c("n", "prop", "total", "diff", "fig_diff", "fig_prop"),
@@ -78,6 +74,7 @@ test_that("1. Set `display` to ('n', 'prop', 'total', 'diff') and change column 
 })
 
 test_that("Set `show` to TRUE then display column 'Type' and change color for tratment group", {
+  out <- test_format_ae_forestly()
   ae_frm <- format_ae_forestly(
     out,
     display = c("n", "prop", "total", "diff"),
@@ -97,6 +94,7 @@ test_that("Set `show` to TRUE then display column 'Type' and change color for tr
 })
 
 test_that("Add variable name not in n, prop, total, diff causes error", {
+  out <- test_format_ae_forestly()
   expect_error(
     format_ae_forestly(
       out,

--- a/tests/testthat/test-independent-testing-meta_forestly.R
+++ b/tests/testthat/test-independent-testing-meta_forestly.R
@@ -1,61 +1,49 @@
-# Create input object
-adsl <- r2rtf::r2rtf_adsl |> dplyr::mutate(TRTA = TRT01A)
-adae <- r2rtf::r2rtf_adae
-
-# Test 1
-test1 <- meta_forestly(
-  adsl,
-  adae,
-  population_term = "apat",
-  observation_term = "wk12",
-  parameter_term = "any;rel;ser"
-)
-
 test_that("There is 1 analysis in the output: ae_forestly", {
+  test1 <- test_meta_forestly_1()
   expect_equal(names(test1$analysis), c("ae_forestly"))
 })
 
 test_that("There is 1 population: apat", {
+  test1 <- test_meta_forestly_1()
   expect_equal(names(test1$population), "apat")
 })
 
 test_that("There is 1 observation: wk12", {
+  test1 <- test_meta_forestly_1()
   expect_equal(names(test1$observation), c("wk12"))
 })
 
 test_that("There are 3 observations: any, rel, ser", {
+  test1 <- test_meta_forestly_1()
   expect_equal(names(test1$parameter), c("any", "rel", "ser"))
 })
 
 test_that("The output is a list", {
+  test1 <- test_meta_forestly_1()
   expect_type(test1, "list")
 })
 
-# Test 2
-test2 <- meta_forestly(adsl, adae,
-  population_term = "trt",
-  population_subset = TRTFL == "Y",
-  observation_term = "trtem",
-  observation_subset = TRTEMFL == "Y" & TRTFL == "Y",
-  parameter_term = "any;g35"
-)
-
 test_that("There is 1 population: trt", {
+  test2 <- test_meta_forestly_2()
   expect_equal(names(test2$population), "trt")
 })
 
 test_that("There is 1 population subset criteria: TRTFL == Y", {
+  test2 <- test_meta_forestly_2()
   expect_equal(test2$population$trt$subset, quote(TRTFL == "Y"))
 })
 
 test_that("There is 1 observation: trtem", {
+  test2 <- test_meta_forestly_2()
   expect_equal(names(test2$observation), "trtem")
 })
 
 test_that("There is 1 observation subset criteria: TREMTFL == Y & TRTFL == Y", {
+  test2 <- test_meta_forestly_2()
   expect_equal(test2$observation$trtem$subset, quote(TRTEMFL == "Y" & TRTFL == "Y"))
 })
 
 test_that("There are 2 observations: any, g35", {
+  test2 <- test_meta_forestly_2()
   expect_equal(names(test2$parameter), c("any", "g35"))
 })


### PR DESCRIPTION
As recommended by [R Packages](https://r-pkgs.org/testing-design.html), this PR makes existing tests self-contained by creating helper functions to wrap the top-level logic that used to have awkward "test file scope". Now all test files only contain individual `test_that()` blocks.