### PR TITLE
`define_parameter` default

### DIFF
--- a/R/ae_forestly.R
+++ b/R/ae_forestly.R
@@ -33,9 +33,6 @@
 #'   meta_forestly(
 #'     dataset_adsl = adsl,
 #'     dataset_adae = adae,
-#'     population_term = "apat",
-#'     observation_term = "wk12",
-#'     parameter = "any;rel"
 #'   ) |>
 #'     prepare_ae_forestly() |>
 #'     format_ae_forestly() |>

--- a/R/format_ae_forestly.R
+++ b/R/format_ae_forestly.R
@@ -46,10 +46,7 @@
 #' adae <- forestly_adae[1:100,]
 #' meta_forestly(
 #'   dataset_adsl = adsl,
-#'   dataset_adae = adae,
-#'   population_term = "apat",
-#'   observation_term = "wk12",
-#'   parameter = "any;rel"
+#'   dataset_adae = adae
 #' ) |>
 #'   prepare_ae_forestly()|>
 #'   format_ae_forestly()

--- a/R/meta_forestly.R
+++ b/R/meta_forestly.R
@@ -38,14 +38,14 @@
 #'   forestly_adsl,
 #'   forestly_adae,
 #'   population_term = "apat",
-#'   observation_term = "wk12",
+#'   observation_term = "safety",
 #'   parameter_term = "any;rel"
 #' )
 meta_forestly <- function(
     dataset_adsl,
     dataset_adae,
-    population_term,
-    observation_term,
+    population_term = "apat",
+    observation_term = "safety",
     parameter_term = "any;rel",
     population_subset = SAFFL == "Y",
     observation_subset = SAFFL == "Y",

--- a/R/prepare_ae_forestly.R
+++ b/R/prepare_ae_forestly.R
@@ -33,10 +33,7 @@
 #' adae <- forestly_adae[1:100,]
 #' meta_forestly(
 #'   dataset_adsl = adsl,
-#'   dataset_adae = adae,
-#'   population_term = "apat",
-#'   observation_term = "wk12",
-#'   parameter = "any;rel"
+#'   dataset_adae = adae
 #' ) |>
 #'   prepare_ae_forestly()
 prepare_ae_forestly <- function(

--- a/R/prepare_ae_forestly.R
+++ b/R/prepare_ae_forestly.R
@@ -67,8 +67,33 @@ prepare_ae_forestly <- function(
 
   if( is.null(parameter)){
     parameters <- names(meta$parameter)
+
+    meta$parameter
   }else{
     parameters <- unlist(strsplit(parameter, ";"))
+  }
+
+  for(i in seq_along(parameters)){
+    para <- meta$parameter[[parameters[i]]]
+    if(is.null(para$var)){
+      para$var <- "AEDECOD"
+    }
+    if(is.null(para$soc)){
+      para$soc <- "AEBODSYS"
+    }
+    if(is.null(para$seq)){
+      para$seq <- sample(1e5:2e5, size = 1)
+    }
+    if(is.null(para$term1)){
+      para$term1 <- ""
+    }
+    if(is.null(para$term2)){
+      para$term2 <- ""
+    }
+    if(is.null(para$summ_row)){
+      para$summ_row <- ""
+    }
+    meta$parameter[[parameters[i]]] <- para
   }
 
   res <- lapply(parameters, function(x) {

--- a/README.md
+++ b/README.md
@@ -56,9 +56,7 @@ library("forestly")
 
 meta_forestly(
   forestly_adsl,
-  forestly_adae,
-  population_term = "apat",
-  observation_term = "wk12"
+  forestly_adae
 ) |>
   prepare_ae_forestly(parameter = "any;rel;ser") |>
   format_ae_forestly() |>

--- a/man/ae_forestly.Rd
+++ b/man/ae_forestly.Rd
@@ -26,9 +26,6 @@ if (interactive()) {
   meta_forestly(
     dataset_adsl = adsl,
     dataset_adae = adae,
-    population_term = "apat",
-    observation_term = "wk12",
-    parameter = "any;rel"
   ) |>
     prepare_ae_forestly() |>
     format_ae_forestly() |>

--- a/man/format_ae_forestly.Rd
+++ b/man/format_ae_forestly.Rd
@@ -63,10 +63,7 @@ adsl <- forestly_adsl[1:100,]
 adae <- forestly_adae[1:100,]
 meta_forestly(
   dataset_adsl = adsl,
-  dataset_adae = adae,
-  population_term = "apat",
-  observation_term = "wk12",
-  parameter = "any;rel"
+  dataset_adae = adae
 ) |>
   prepare_ae_forestly()|>
   format_ae_forestly()

--- a/man/meta_forestly.Rd
+++ b/man/meta_forestly.Rd
@@ -7,8 +7,8 @@
 meta_forestly(
   dataset_adsl,
   dataset_adae,
-  population_term,
-  observation_term,
+  population_term = "apat",
+  observation_term = "safety",
   parameter_term = "any;rel",
   population_subset = SAFFL == "Y",
   observation_subset = SAFFL == "Y",
@@ -45,7 +45,7 @@ meta_forestly(
   forestly_adsl,
   forestly_adae,
   population_term = "apat",
-  observation_term = "wk12",
+  observation_term = "safety",
   parameter_term = "any;rel"
 )
 }

--- a/man/prepare_ae_forestly.Rd
+++ b/man/prepare_ae_forestly.Rd
@@ -47,10 +47,7 @@ adsl <- forestly_adsl[1:100,]
 adae <- forestly_adae[1:100,]
 meta_forestly(
   dataset_adsl = adsl,
-  dataset_adae = adae,
-  population_term = "apat",
-  observation_term = "wk12",
-  parameter = "any;rel"
+  dataset_adae = adae
 ) |>
   prepare_ae_forestly()
 }

--- a/vignettes/forestly-cran.Rmd
+++ b/vignettes/forestly-cran.Rmd
@@ -18,9 +18,7 @@ forestly_adae$TRTA <- factor(forestly_adae$TRTA, levels = c("Xanomeline Low Dose
 
 meta_forestly(
   dataset_adsl = forestly_adsl,
-  dataset_adae = forestly_adae,
-  population_term = "apat",
-  observation_term = "wk12"
+  dataset_adae = forestly_adae
 ) |>
   prepare_ae_forestly(parameter = "any;rel;ser") |>
   format_ae_forestly() |>

--- a/vignettes/forestly.Rmd
+++ b/vignettes/forestly.Rmd
@@ -50,8 +50,6 @@ forestly_adae$TRTA <- factor(forestly_adae$TRTA, levels = c("Xanomeline Low Dose
 meta_forestly(
   dataset_adsl = forestly_adsl,
   dataset_adae = forestly_adae,
-  population_term = "apat",
-  observation_term = "wk12",
   parameter_term = "any;rel;ser"
 ) |>
   prepare_ae_forestly() |>
@@ -89,8 +87,6 @@ to generate the interactive forest plot.
 meta_forestly(
   dataset_adsl = forestly_adsl,
   dataset_adae = forestly_adae,
-  population_term = "apat",
-  observation_term = "wk12",
   parameter_term = "any;rel;ser"
 )
 ```

--- a/vignettes/layout.Rmd
+++ b/vignettes/layout.Rmd
@@ -40,8 +40,6 @@ The `outdata` contains all the parameters required to generate the interactive f
 metadata <- meta_forestly(
   dataset_adsl = forestly_adsl_3grp,
   dataset_adae = forestly_adae_3grp,
-  population_term = "apat",
-  observation_term = "wk12",
   parameter_term = "any;rel;ser"
 )
 


### PR DESCRIPTION
Avoid unnecessary default values for `forestly` while calling `metalite.ae`. 

The example below is from #20 to show it can properly handle `define_parameters` with default values. 

Please merge #48 before this PR. 

```
devtools::load_all()
library(metalite)

adae_tmp <- forestly_adae 
adae_tmp$AEACN[1:10] <- "DOSE REDUCED"

meta_new <- meta_adam(
  population = forestly_adsl,
  observation = adae_tmp
) |>
  define_plan(plan = metalite::plan(
    analysis = "ae_forestly",
    population = "apat",
    observation = "wk12",
    parameter = "any;ser;reduc"
  )
  ) |>
  define_population(
    name = "apat",
    group = "TRTA",
  ) |>
  define_observation(
    name = "wk12",
    group = "TRTA",
    label = "Weeks 0 to 24"
  ) |>
  define_parameter(
    name = "reduc",
    subset = AEACN == "DOSE REDUCED",
    label = "adverse events resulting in dose reduction"
  ) |>
  define_analysis(
    name = "ae_forestly",
    label = "Interactive forest plot"
  ) |>
  meta_build()

meta_new |>
  prepare_ae_forestly(parameter = "any;ser;reduc") |>
  format_ae_forestly() |>
  ae_forestly()
``` 