### PR TITLE
Avoid using `defaultColDef` to fix the bug for reactR >= 0.6.0

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -32,7 +32,6 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, reactR@0.5.0, local::.
           needs: website
 
       - name: Build site

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -32,6 +32,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          extra-packages: any::pkgdown, local::.
           needs: website
 
       - name: Build site

--- a/R/reactable2.R
+++ b/R/reactable2.R
@@ -97,7 +97,7 @@ reactable2 <- function(
     filterable = filterable,
     searchable = searchable,
     defaultPageSize = defaultPageSize,
-    defaultColDef = col_def,
+    #defaultColDef = col_def,
     showPageSizeOptions = showPageSizeOptions,
     borderless = borderless,
     striped = striped,

--- a/R/reactable2.R
+++ b/R/reactable2.R
@@ -97,7 +97,7 @@ reactable2 <- function(
     filterable = filterable,
     searchable = searchable,
     defaultPageSize = defaultPageSize,
-    #defaultColDef = col_def,
+    # defaultColDef = col_def, # This breaks rendering under reactR >= 0.6.0
     showPageSizeOptions = showPageSizeOptions,
     borderless = borderless,
     striped = striped,


### PR DESCRIPTION
Fixes #65

The root cause of the issue is using `defaultColDef` with a `SharedData` object defined by `crosslink`. 

Fix the issue by just avoiding using the `defaultColDef` because every column has been defined and `reactable2` is an internal function