### PR TITLE
Fix issue 89 npop display

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Claude Code Assistant Instructions
 
 ## Project Overview
-This is the forestly R package, which creates interactive forest plots for clinical trial data analysis. The package is built on top of metalite and metalite.ae packages and uses reactable for interactive tables.
+This is the forestly R package, which creates interactive forest plots for clinical trial data analysis. The package is built on top of metalite and metalite.ae packages and uses reactable for interactive tables with Plotly.js for interactive visualizations.
 
 ## Development Guidelines
 
@@ -18,7 +18,9 @@ This is the forestly R package, which creates interactive forest plots for clini
 
 ### Key Functions
 - `ae_forestly()`: Main function to create interactive forest plots
+- `format_ae_forestly()`: Formats AE data and configures Plotly visualizations
 - `format_ae_listing()`: Formats AE listing data
+- `sparkline_point_js()`: Generates JavaScript/Plotly code for interactive sparkline plots
 - `propercase()`: Converts strings to proper case (handles factors)
 - `titlecase()`: Converts strings to title case using tools::toTitleCase (handles factors)
 
@@ -52,6 +54,8 @@ devtools::document()
 - metalite.ae
 - reactable
 - reactR
+- plotly (via JavaScript integration)
+- brew (for template processing)
 - tools (base R)
 
 ## Testing Data
@@ -65,3 +69,6 @@ The package includes test data in `data/`:
 - The `ae_listing.R` file contains functions that handle factor inputs, which was a recent fix
 - Test files should use `devtools::load_all()` or source the R files directly for testing
 - The package uses testthat for unit testing framework
+- Interactive plots use Plotly.js via JavaScript templates in `inst/js/`
+- The y-axis ordering in `format_ae_forestly.R` affects the visual display in interactive plots
+- When debugging interactive plot issues, check both R code and JavaScript template files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# Claude Code Assistant Instructions
+
+## Project Overview
+This is the forestly R package, which creates interactive forest plots for clinical trial data analysis. The package is built on top of metalite and metalite.ae packages and uses reactable for interactive tables.
+
+## Development Guidelines
+
+### Testing
+- load project using `devtools::load_all()`
+- Run tests using: `devtools::test()`
+- Run specific test files using: `devtools::test(filter = "filename")`
+- Before running tests, ensure required packages are installed (metalite, metalite.ae, reactable, reactR)
+
+### Code Style
+- Follow tidyverse style guide
+- Use `|>` pipe operator (R 4.1+)
+- Functions should handle both character vectors and factors robustly
+
+### Key Functions
+- `ae_forestly()`: Main function to create interactive forest plots
+- `format_ae_listing()`: Formats AE listing data
+- `propercase()`: Converts strings to proper case (handles factors)
+- `titlecase()`: Converts strings to title case using tools::toTitleCase (handles factors)
+
+### Before Committing
+- Run linting: Check for any linting issues in the IDE
+- Run tests: `devtools::test()` to ensure all tests pass
+- Check documentation: `devtools::document()` if roxygen comments are updated
+
+### Branch Strategy
+- Main branch: `main`
+- Feature branches: Use descriptive names like `fix-factor-handling` or `add-new-feature`
+- Always create pull requests for merging into main
+
+### Common Commands
+```r
+# Load all functions for development
+devtools::load_all()
+
+# Run all tests
+devtools::test()
+
+# Check package
+devtools::check()
+
+# Build documentation
+devtools::document()
+```
+
+## Package Dependencies
+- metalite
+- metalite.ae
+- reactable
+- reactR
+- tools (base R)
+
+## Testing Data
+The package includes test data in `data/`:
+- forestly_adae.rda
+- forestly_adae_3grp.rda
+- forestly_adsl.rda
+- forestly_adsl_3grp.rda
+
+## Notes for Future Development
+- The `ae_listing.R` file contains functions that handle factor inputs, which was a recent fix
+- Test files should use `devtools::load_all()` or source the R files directly for testing
+- The package uses testthat for unit testing framework

--- a/R/format_ae_forestly.R
+++ b/R/format_ae_forestly.R
@@ -131,7 +131,7 @@ format_ae_forestly <- function(
   tbl_prop <- outdata$prop[, 1:n_group]
   y <- rep(NA, n_group)
   y[outdata$reference_group] <- mean(1:n_group1)
-  y[-outdata$reference_group] <- 1:n_group1
+  y[-outdata$reference_group] <- rev(1:n_group1)
 
   # Calculate the range of the forest plot
   if (is.null(prop_range)) {
@@ -199,7 +199,7 @@ format_ae_forestly <- function(
     x = names(outdata$diff),
     x_lower = names(outdata$ci_lower),
     x_upper = names(outdata$ci_upper),
-    y = 1:ncol(outdata$diff),
+    y = rev(1:ncol(outdata$diff)),
     xlim = fig_diff_range,
     color = fig_diff_color,
     width = width_fig,


### PR DESCRIPTION
The change should fix the order in plotly figure. 

```
# Example demonstrating the fix for issue #89
# Consistent treatment group ordering between table and interactive plot

devtools::load_all()

# Create the interactive forest plot with 3 groups
library("forestly")

meta_forestly(
  dataset_adsl = forestly_adsl_3grp,
  dataset_adae = forestly_adae_3grp,
  parameter_term = "any;rel;ser",
  population_subset = SAFFL == "Y",
  observation_subset = SAFFL == "Y"
) |>
  prepare_ae_forestly(parameter = "any;rel;ser") |>
  format_ae_forestly() |>
  ae_forestly()
```

<img width="2848" height="936" alt="image" src="https://github.com/user-attachments/assets/bffd53ba-d355-4489-b35a-e9a3dfae5d1f" />
