### PR TITLE
Update the example in `rtf_static_forestly()`

### DIFF
--- a/R/rtf_static_forestly.R
+++ b/R/rtf_static_forestly.R
@@ -49,8 +49,8 @@
 #'   labels = c("Low Dose", "Placebo")
 #' )
 #' outdata <- meta_forestly(
-#'   dataset_adsl = forestly_adsl,
-#'   dataset_adae = forestly_adae
+#'   dataset_adsl = forestly_adsl[1:40, ],
+#'   dataset_adae = forestly_adae[1:40, ]
 #' ) |>
 #'   prepare_ae_forestly()|>
 #'   format_ae_forestly()

--- a/man/rtf_static_forestly.Rd
+++ b/man/rtf_static_forestly.Rd
@@ -66,8 +66,8 @@ forestly_adae$TRTA <- factor(
   labels = c("Low Dose", "Placebo")
 )
 outdata <- meta_forestly(
-  dataset_adsl = forestly_adsl,
-  dataset_adae = forestly_adae
+  dataset_adsl = forestly_adsl[1:40, ],
+  dataset_adae = forestly_adae[1:40, ]
 ) |>
   prepare_ae_forestly()|>
   format_ae_forestly()


### PR DESCRIPTION
This PR updates the example to use fewer data records in `rtf_static_forestly()` to reduce long running time.