### PR TITLE
Update .Rbuildignore to remove test snapshots

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,7 +9,6 @@
 ^LICENSES_THIRD_PARTY$
 ^\.github$
 ^codecov\.yml$
-^tests/testthat/_snaps$
 
 ^vignettes/design-pattern.Rmd$
 ^vignettes/forestly.Rmd$


### PR DESCRIPTION
Remove test snapshots from R build ignore list. It is used for passing the R build check