### PR TITLE
119 enable user to hide the slide bar on forest plot

### DIFF
--- a/R/ae_forestly.R
+++ b/R/ae_forestly.R
@@ -60,9 +60,7 @@ ae_forestly <- function(outdata,
   # Set filter parameter
   if (!is.null(filter)) {
     display_filter = TRUE
-    if (!filter %in% c("prop", "n")) {
-      stop("filter must be either 'prop' for proportion or 'n' for count")
-    }
+    filter <- match.arg(filter, c("prop", "n"))
   } else {
     display_filter = FALSE
   }

--- a/man/ae_forestly.Rd
+++ b/man/ae_forestly.Rd
@@ -8,7 +8,7 @@ ae_forestly(
   outdata,
   display_soc_toggle = TRUE,
   display_diff_toggle = FALSE,
-  filter = NULL,
+  filter = c("prop", "n"),
   filter_label = NULL,
   filter_range = NULL,
   ae_label = NULL,

--- a/tests/testthat/test-ae_forestly.R
+++ b/tests/testthat/test-ae_forestly.R
@@ -6,6 +6,7 @@ test_that("ae_forestly(): default setting can be executed without error", {
   expect_equal(html$name, "div")
   expect_equal(html$attribs$class, "container-fluid crosstalk-bscols")
   expect_true(grepl("width:1400px", html$children[[1]], fixed = TRUE))
+  expect_true(grepl("Incidence (%) in One or More Treatment Groups", html$children[[1]], fixed = TRUE))
 })
 
 test_that("ae_forestly(): test filter and width option", {


### PR DESCRIPTION
This PR updates `ae_forestly()` so that a user can control the display of the slider bar. If NULL is specified in `filter`, the slider bar will not be displayed.

<Example 1. Default: `filter = NULL`>
```
adsl <- forestly::forestly_adsl_3grp
adae <- forestly::forestly_adae_3grp
meta_forestly(
  dataset_adsl = adsl,
  dataset_adae = adae,
) |>
  prepare_ae_forestly() |>
  format_ae_forestly(c("n", "prop", "fig_prop", "fig_diff", "diff")) |>
  ae_forestly()
```
<img width="798" height="251" alt="2026-03-12_forestly_slider-bar1" src="https://github.com/user-attachments/assets/4fe090ca-3f00-40d1-810e-4cbc7f157419" />

<Example 2. `filter = "n"`>
```
adsl <- forestly::forestly_adsl_3grp
adae <- forestly::forestly_adae_3grp
meta_forestly(
  dataset_adsl = adsl,
  dataset_adae = adae,
) |>
  prepare_ae_forestly() |>
  format_ae_forestly(c("n", "prop", "fig_prop", "fig_diff", "diff")) |>
  ae_forestly(filter = "n")
```
<img width="797" height="302" alt="2026-03-12_forestly_slider-bar2" src="https://github.com/user-attachments/assets/3be75e41-c9e5-4f4a-ba60-eb11d31e5c01" />