### PR TITLE
Check-in - Add 'bisection' argument to 'prepare_ae_forestly' per Issu…

### DIFF
--- a/R/prepare_ae_forestly.R
+++ b/R/prepare_ae_forestly.R
@@ -19,11 +19,23 @@
 #' Prepare datasets for interactive forest plot
 #'
 #' @inheritParams metalite.ae::prepare_ae_specific
+#' @param meta A metadata object created by metalite.
+#' @param population A character value of population term name.
+#'   The term name is used as key to link information.
+#' @param observation A character value of observation term name.
+#'   The term name is used as key to link information.
+#' @param parameter A character value of parameter term name.
+#'   The term name is used as key to link information.
+#' @param components A character vector of components name, default value is `"par"`.
+#' @param reference_group An integer to indicate reference group.
+#'   Default is 2 if there are 2 groups, otherwise, the default is 1.
 #' @param ae_listing_display A vector of name of variables used to display
 #'   on AE listing table.
 #' @param ae_listing_unique A logical value to display only unique records
 #'   on AE listing table.
-#'
+#' @param bisection A numeric value. A control parameter for the bisection
+#'   method used to calculate confidence the lower and upper confidence
+#'   interval bounds for the risk. The default value is `1e2`.
 #' @return An `outdata` object.
 #'
 #' @export

--- a/R/prepare_ae_forestly.R
+++ b/R/prepare_ae_forestly.R
@@ -47,7 +47,10 @@ prepare_ae_forestly <- function(
       "USUBJID", "SITEID", "SEX", "RACE", "AGE", "ASTDY", "AESER",
       "AEREL", "AEACN", "AEOUT", "ADURN", "ADURU"
     ),
-    ae_listing_unique = FALSE) {
+    ae_listing_unique = FALSE,
+    bisection = 1e2,
+    ...
+    ) {
   if (is.null(population)) {
     if (length(meta$population) == 1) {
       population <- meta$population[[1]]$name
@@ -103,7 +106,10 @@ prepare_ae_forestly <- function(
       components = components,
       reference_group = reference_group
     ) |>
-      metalite.ae::extend_ae_specific_inference() |>
+      metalite.ae::extend_ae_specific_inference(
+        bisection = bisection,
+        ...
+      ) |>
       collect_ae_listing(display = ae_listing_display) |>
       format_ae_listing(display_unique_records = ae_listing_unique)
   })

--- a/R/prepare_ae_forestly.R
+++ b/R/prepare_ae_forestly.R
@@ -36,6 +36,7 @@
 #' @param bisection A numeric value. A control parameter for the bisection
 #'   method used to calculate confidence the lower and upper confidence
 #'   interval bounds for the risk. The default value is `1e2`.
+#' @param ... Additional arguments passed to [metalite.ae::rate_compare_sum()].
 #' @return An `outdata` object.
 #'
 #' @export

--- a/man/prepare_ae_forestly.Rd
+++ b/man/prepare_ae_forestly.Rd
@@ -30,7 +30,7 @@ The term name is used as key to link information.}
 \item{parameter}{A character value of parameter term name.
 The term name is used as key to link information.}
 
-\item{components}{A character vector of components name.}
+\item{components}{A character vector of components name, default value is \code{"par"}.}
 
 \item{reference_group}{An integer to indicate reference group.
 Default is 2 if there are 2 groups, otherwise, the default is 1.}
@@ -40,6 +40,10 @@ on AE listing table.}
 
 \item{ae_listing_unique}{A logical value to display only unique records
 on AE listing table.}
+
+\item{bisection}{A numeric value. A control parameter for the bisection
+method used to calculate confidence the lower and upper confidence
+interval bounds for the risk. The default value is \code{1e2}.}
 }
 \value{
 An \code{outdata} object.

--- a/man/prepare_ae_forestly.Rd
+++ b/man/prepare_ae_forestly.Rd
@@ -44,6 +44,8 @@ on AE listing table.}
 \item{bisection}{A numeric value. A control parameter for the bisection
 method used to calculate confidence the lower and upper confidence
 interval bounds for the risk. The default value is \code{1e2}.}
+
+\item{...}{Additional arguments passed to \code{\link[metalite.ae:rate_compare_sum]{metalite.ae::rate_compare_sum()}}.}
 }
 \value{
 An \code{outdata} object.

--- a/man/prepare_ae_forestly.Rd
+++ b/man/prepare_ae_forestly.Rd
@@ -13,7 +13,9 @@ prepare_ae_forestly(
   reference_group = NULL,
   ae_listing_display = c("USUBJID", "SITEID", "SEX", "RACE", "AGE", "ASTDY", "AESER",
     "AEREL", "AEACN", "AEOUT", "ADURN", "ADURU"),
-  ae_listing_unique = FALSE
+  ae_listing_unique = FALSE,
+  bisection = 100,
+  ...
 )
 }
 \arguments{


### PR DESCRIPTION
The bisection argument added to prepare_ae_forestly function definition that is passed down to metalite.ae::extend_ae_specific_inference and then to metalite.ae::rate_compare_sum.  