### PR TITLE
Add messages when variables are not available listings

### DIFF
--- a/R/prepare_ae_forestly.R
+++ b/R/prepare_ae_forestly.R
@@ -64,6 +64,23 @@ prepare_ae_forestly <- function(
     }
   }
 
+  if (population == observation) {
+    if (any(!meta$population[[population]]$var %in% names(meta$data_observation))) {
+      stop(paste0(
+        "When the same term is specified for population and observation, ",
+        "the variable specified in population should be included in the observation dataset."
+        ))
+    }
+  }
+
+  if (any(!ae_listing_display %in% names(meta$data_observation))) {
+    warning(paste0(
+      "The variables specified in ae_listing_display should be included in the observation dataset. ",
+      "Only the variables included in the observation dataset will be displayed on AE listing table."
+      ))
+    ae_listing_display <- ae_listing_display[ae_listing_display %in% names(meta$data_observation)]
+  }
+
   if (is.null(parameter)) {
     parameters <- names(meta$parameter)
 

--- a/R/prepare_ae_forestly.R
+++ b/R/prepare_ae_forestly.R
@@ -64,19 +64,20 @@ prepare_ae_forestly <- function(
     }
   }
 
-  if (population == observation) {
-    if (any(!meta$population[[population]]$var %in% names(meta$data_observation))) {
-      stop(paste0(
-        "When the same term is specified for population and observation, ",
-        "the variable specified in population should be included in the observation dataset."
-        ))
-    }
-  }
+  # Temporary Processing
+  data_observation <- meta$data_observation |>
+    merge(
+      meta$data_population,
+      by = "USUBJID",
+      all.x = TRUE,
+      suffixes = c("", ".pop")
+    )
+  meta$data_observation <- data_observation[, !grepl("\\.pop$", names(data_observation))]
 
   if (any(!ae_listing_display %in% names(meta$data_observation))) {
     warning(paste0(
-      "The variables specified in ae_listing_display should be included in the observation dataset. ",
-      "Only the variables included in the observation dataset will be displayed on AE listing table."
+      "The variables specified in ae_listing_display should be included in the input dataset. ",
+      "Only the variables included in the input dataset will be displayed on AE listing table."
       ))
     ae_listing_display <- ae_listing_display[ae_listing_display %in% names(meta$data_observation)]
   }


### PR DESCRIPTION
This PR updates `prepare_ae_forestly()` to:
~1. raise an error when the `population` and `observation` terms are the same and the variables specified in `var` for `population` do not exist in data_observation; and~
2. issue a warning when `display_ae_listing` variables do not exist in data_observation, and display only the variables that do exist in data_observation.