### PR TITLE
128 bug of format ae listing -- sex race age

### DIFF
--- a/R/ae_listing.R
+++ b/R/ae_listing.R
@@ -208,11 +208,17 @@ format_ae_listing <- function(outdata, display_unique_records = FALSE) {
   }
   attr(res[["Participant_ID"]], "label") <- NULL
 
-  res[["Gender"]] <- tools::toTitleCase(res[["SEX"]])
+  if ("SEX" %in% toupper(names(res))) {
+    res[["Gender"]] <- tools::toTitleCase(res[["SEX"]])
+  }
 
-  res[["Race"]] <- tools::toTitleCase(tolower(res[["RACE"]]))
+  if ("RACE" %in% toupper(names(res))) {
+    res[["Race"]] <- tools::toTitleCase(tolower(res[["RACE"]]))
+  }
 
-  res[["Age"]] <- res[["AGE"]]
+  if ("AGE" %in% toupper(names(res))) {
+    res[["Age"]] <- res[["AGE"]]
+  }
 
   res[["Treatment_Group"]] <- res[[obs_group]]
 

--- a/R/prepare_ae_forestly.R
+++ b/R/prepare_ae_forestly.R
@@ -19,16 +19,6 @@
 #' Prepare datasets for interactive forest plot
 #'
 #' @inheritParams metalite.ae::prepare_ae_specific
-#' @param meta A metadata object created by metalite.
-#' @param population A character value of population term name.
-#'   The term name is used as key to link information.
-#' @param observation A character value of observation term name.
-#'   The term name is used as key to link information.
-#' @param parameter A character value of parameter term name.
-#'   The term name is used as key to link information.
-#' @param components A character vector of components name, default value is `"par"`.
-#' @param reference_group An integer to indicate reference group.
-#'   Default is 2 if there are 2 groups, otherwise, the default is 1.
 #' @param ae_listing_display A vector of name of variables used to display
 #'   on AE listing table.
 #' @param ae_listing_unique A logical value to display only unique records

--- a/man/prepare_ae_forestly.Rd
+++ b/man/prepare_ae_forestly.Rd
@@ -30,7 +30,7 @@ The term name is used as key to link information.}
 \item{parameter}{A character value of parameter term name.
 The term name is used as key to link information.}
 
-\item{components}{A character vector of components name, default value is \code{"par"}.}
+\item{components}{A character vector of components name.}
 
 \item{reference_group}{An integer to indicate reference group.
 Default is 2 if there are 2 groups, otherwise, the default is 1.}


### PR DESCRIPTION
This PR fixes a bug by updating ae_listing() to prevent errors that occur when age, sex, or race values are unspecified in the listing.

Example:
```
devtools::load_all()
adsl <- forestly_adsl[1:100, ]
adae <- forestly_adae[1:100, ]
meta_forestly(
  dataset_adsl = adsl,
  dataset_adae = adae,
) |>
  prepare_ae_forestly(
    ae_listing_display = c("USUBJID", "BMIBL") # AGE, SEX or RACE is not included in a listing
  ) |>
  format_ae_forestly() |>
  ae_forestly()
```

Also, update `roxygen2` params of `prepare_ae_forestly()` due to duplication. The removed params are covered by `@inheritParames`.